### PR TITLE
Portability; version number; git ignore; whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 test
+
+rd3v*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "render-d3-video",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Render a seamless video screen recording from a locally served site",
 	"main": "render-d3-video.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "render-d3-video",
-	"version": "0.0.6",
+	"version": "0.1.0",
 	"description": "Render a seamless video screen recording from a locally served site",
 	"main": "render-d3-video.js",
 	"scripts": {

--- a/render-d3-video.js
+++ b/render-d3-video.js
@@ -6,6 +6,7 @@ const d3 = require('d3');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
 const shell = require('shelljs');
+const readline = require('readline');
 
 const VERSION = '0.0.4';
 const FRAME_RATE = 1000 / 60;
@@ -36,7 +37,7 @@ function printProgress(index, total) {
 	const i = index + 1;
 	const percent = d3.format('.1%')(i / total);
 	if (process.stdout.clearLine) process.stdout.clearLine();
-	process.stdout.cursorTo(0);
+	readline.cursorTo(0);
 	process.stdout.write(`${percent} (${i} of ${total})`);
 }
 
@@ -47,7 +48,7 @@ function invalid() {
 	if (isNaN(height)) return '--height is not a valid number';
 	if (isNaN(port)) '--port is not a valid number';
 	if (!output) return '--output is not a valid string';
-	if (isNaN(deviceScaleFactor)) return '--deviceScaleFactor is not a valid number';	
+	if (isNaN(deviceScaleFactor)) return '--deviceScaleFactor is not a valid number';
 	return false;
 }
 
@@ -70,7 +71,7 @@ function cleanDir(path) {
 }
 
 async function renderFrames(path) {
-	
+
 	console.log(`loading http://localhost:${port}...`);
 	const framePath = `${path}/frames`;
 
@@ -82,7 +83,7 @@ async function renderFrames(path) {
 	} catch(error) {
 		return Promise.reject('error loading page');
 	}
-	
+
 
 	try {
 		// let the page load

--- a/render-d3-video.js
+++ b/render-d3-video.js
@@ -8,7 +8,9 @@ const rimraf = require('rimraf');
 const shell = require('shelljs');
 const readline = require('readline');
 
-const VERSION = '0.0.4';
+const package = require('./package.json');
+const VERSION = package.version;
+
 const FRAME_RATE = 1000 / 60;
 const CWD = process.cwd();
 


### PR DESCRIPTION
**Portability**: `process.stdout.cursorTo` was removed from node in 9, but kept in mac node.  It was moved to `readline.cursorTo`.  Patched.

**Version number**: you were on 0.0.8 in `package.json`, but you had an internal constant for `commander` reporting `0.0.6`.  Bumped package to `0.1.1` over functionality changes, then pulled the internal constant from package so that it'll never be out of date again.

**.gitignore**: I excluded the naming pattern of video output from commits

**Whitespace**: my editor removes trailing whitespace, so, that happened here